### PR TITLE
kivy.utils.platform returns 'macosx' instead of 'osx' on Kivy v1.10.1dev0

### DIFF
--- a/notification.py
+++ b/notification.py
@@ -110,7 +110,7 @@ class Notification(App):
     def _hide_window(self, *args):
         if platform == 'win':
             self._hide_w32_window()
-        elif platform in ('linux', 'osx'):
+        elif platform in ('linux', 'macosx'):
             self._hide_x11_window()
 
     def _hide_w32_window(self):

--- a/utils.py
+++ b/utils.py
@@ -28,11 +28,11 @@ def sys_resolution():
             'x': res[0],
             'y': res[1]
         }
-    elif platform == 'osx':
+    elif platform == 'macosx':
         o = check_output(['system_profiler', 'SPDisplaysDataType'])
-        start = o.find('Resolution: ')
-        end = o.find('\n', start=start)
-        o = o[start:end].strip().split(' ')
+        start = o.find(b'Resolution: ')
+        end = o.find(b'\n', start)
+        o = o[start:end].strip().split(b' ')
         RESOLUTION = {
             'x': int(o[1]),
             'y': int(o[3])


### PR DESCRIPTION
also fixing byte string encoding on osx